### PR TITLE
Update 80-pacredir for posix sh compatibility

### DIFF
--- a/networkmanager/80-pacredir
+++ b/networkmanager/80-pacredir
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "${2}" == "up" ]; then
+if [ "${2}" = "up" ]; then
 	if systemctl is-active -q pacredir.service; then
 		systemctl reload pacredir.service
 	fi


### PR DESCRIPTION
Changes == to = so it can work with dash and other shells as /bin/sh