### PR TITLE
move architecture and id to TXT data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ CFLAGS_EXTRA	+= $(shell pkg-config --libs --cflags iniparser)
 LDFLAGS	+= -Wl,-z,now -Wl,-z,relro -pie
 
 # the distribution ID
-ARCH	:= $(shell shopt -u extglob && source /etc/makepkg.conf && echo $${CARCH//_/-})
-ID	:= $(shell shopt -u extglob && source /etc/os-release && echo $${ID//_/-})
+ARCH	:= $(shell shopt -u extglob && source /etc/makepkg.conf && echo $$CARCH)
+ID	:= $(shell shopt -u extglob && source /etc/os-release && echo $$ID)
 
 # this is just a fallback in case you do not use git but downloaded
 # a release tarball...

--- a/config.def.h
+++ b/config.def.h
@@ -38,7 +38,9 @@
 #define PORT_PACSERVE	7078
 
 /* avahi service names */
-#define PACSERVE	"_pacserve-" ID "-" ARCH "._tcp"
+#define PACSERVE	"_pacserve._tcp"
+#define PACSERVE_ID	"id=" ID
+#define PACSERVE_ARCH	"arch=" ARCH
 
 /* path to the config file */
 #define CONFIGFILE	"/etc/pacredir.conf"

--- a/pacredir.c
+++ b/pacredir.c
@@ -181,6 +181,18 @@ static void resolve_callback(AvahiServiceResolver *r,
 			break;
 
 		case AVAHI_RESOLVER_FOUND:
+			if (!avahi_string_list_find(txt, PACSERVE_ID)) {
+				if (verbose > 0)
+					write_log(stderr, "Service %s (port %d) on host %s on interface %s does not match %s\n",
+							type, port, host, intname, PACSERVE_ID);
+				break;
+			}
+			if (!avahi_string_list_find(txt, PACSERVE_ARCH)) {
+				if (verbose > 0)
+					write_log(stderr, "Service %s (port %d) on host %s on interface %s does not match %s\n",
+							type, port, host, intname, PACSERVE_ARCH);
+				break;
+			}
 			avahi_address_snprint(ipaddress, AVAHI_ADDRESS_STR_MAX, address);
 
 			if (verbose > 0)

--- a/pacredir.h
+++ b/pacredir.h
@@ -41,6 +41,7 @@
 #include <avahi-client/lookup.h>
 #include <avahi-common/error.h>
 #include <avahi-common/simple-watch.h>
+#include <avahi-common/strlst.h>
 
 /* various headers needing linker options */
 #include <curl/curl.h>

--- a/systemd/pacserve-announce.service.in
+++ b/systemd/pacserve-announce.service.in
@@ -15,7 +15,7 @@ Requisite=avahi-daemon.service
 
 [Service]
 EnvironmentFile=/etc/pacserve.conf
-ExecStart=/usr/bin/avahi-publish -s "pacserve on %l" _pacserve-%ID%-%ARCH%._tcp ${PORT}
+ExecStart=/usr/bin/avahi-publish -s "pacserve on %l" _pacserve._tcp ${PORT} id=%ID% arch=%ARCH%
 DynamicUser=on
 ProtectSystem=full
 ProtectHome=on


### PR DESCRIPTION
This also keeps the service name below the allowed 15 characters.