### PR TITLE
Change pacredir-status.destop to Application from Link

### DIFF
--- a/desktop/pacredir-status.desktop
+++ b/desktop/pacredir-status.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
-Type=Link
+Type=Application
 Version=1.0
 Name=pacredir status
 GenericName=Status and statistics for pacredir
 Comment=Show status and statistics for pacredir
 Icon=/usr/share/pixmaps/pacredir.png
-URL=http://localhost:7077/
+Exec=/usr/bin/xdg-open http://localhost:7077/
 Categories=System;PackageManager
 Keywords=system;PackageManager


### PR DESCRIPTION
kbuildsycoca6 complains about pacredir-status.desktop not having an 'Application' or 'Service' as the type - this switches to using xdg-open to navigate to the URL and act as an application